### PR TITLE
8 env based monolith and microservice switching

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,3 +4,4 @@ DB_NAME=reakgo
 SESSION_KEY=reakgo
 SESSION_NAME=reakgo
 WEB_PORT=4000
+APP_IS=microservice or monolith

--- a/env.example
+++ b/env.example
@@ -4,4 +4,5 @@ DB_NAME=reakgo
 SESSION_KEY=reakgo
 SESSION_NAME=reakgo
 WEB_PORT=4000
-APP_IS=microservice or monolith
+# values can be microservice or monolith
+APP_IS=

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"strconv"
 
 	//"log"
 	//"fmt"
@@ -116,136 +117,167 @@ func RenderTemplate(w http.ResponseWriter, r *http.Request, template string, dat
 	View.ExecuteTemplate(w, template, tmplData)
 }
 
-func ParseDataFromRequest(r *http.Request) (map[string]interface{}, error) {
-	if os.Getenv("APP_IS") == "monolith" {
-		var jsonDataMap map[string]interface{}
-		result := make(map[string]interface{})
-
-		// Read JSON data from the HTTP request body
-		decoder := json.NewDecoder(r.Body)
-		err := decoder.Decode(&jsonDataMap)
-		if err != nil {
-			return result, err
-		}
-
-		// Close the request body to prevent resource leaks
-		defer r.Body.Close()
-		// Iterate through the JSON values
-		for key, value := range jsonDataMap {
-			result[key] = value
-		}
-
-		return result, nil
-	} else if os.Getenv("APP_IS") == "microservice" {
-		formData := make(map[string]interface{})
-		err := r.ParseForm()
-		if err != nil {
-			return formData, err
-		}
-
-		// Iterate through the form values
-		for key, values := range r.Form {
-			// If there's only one value for the key, store it directly
-			if len(values) == 1 {
-				formData[key] = values[0]
-			} else {
-				// If there are multiple values, store them as a slice
-				formData[key] = values
-			}
-		}
-
-		return formData, nil
+func ParseDataFromPostFormRequest(r *http.Request) (map[string]interface{}, error) {
+	formData := make(map[string]interface{})
+	err := r.ParseForm()
+	if err != nil {
+		return formData, err
 	}
-	return nil, errors.New("The value of the environment variable APP_IS is invalid or Not set. It should be [monolith or microservice]. Please update the environment variable and try again.")
+
+	// Iterate through the form values
+	for key, values := range r.Form {
+		// If there's only one value for the key, store it directly
+		if len(values) == 1 {
+			formData[key] = values[0]
+		} else {
+			// If there are multiple values, store them as a slice
+			formData[key] = values
+		}
+	}
+
+	return formData, nil
 }
 
-func StrictParseDataFromRequest(r *http.Request, structure interface{}) error {
-	if os.Getenv("APP_IS") == "monolith" {
-		err := json.NewDecoder(r.Body).Decode(structure)
-		if err != nil {
-			return err
-		}
+func ParseDataFromJson(r *http.Request) (map[string]interface{}, error) {
+	var jsonDataMap map[string]interface{}
+	result := make(map[string]interface{})
+
+	// Read JSON data from the HTTP request body
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&jsonDataMap)
+	if err != nil {
+		return result, err
+	}
+
+	// Close the request body to prevent resource leaks
+	defer r.Body.Close()
+	// Iterate through the JSON values
+	for key, value := range jsonDataMap {
+		result[key] = value
+	}
+
+	return result, nil
+}
+
+func StrictParseDataFromJson(r *http.Request, structure interface{}) error {
+	err := json.NewDecoder(r.Body).Decode(structure)
+	if err != nil {
 		return err
+	}
+	return err
 
-	} else if os.Getenv("APP_IS") == "microservice" {
+}
 
-		err := r.ParseForm()
-		if err != nil {
-			return err
+func StrictParseDataFromPostFormRequest(r *http.Request, structure interface{}) error {
+	err := r.ParseForm()
+	if err != nil {
+		return err
+	}
+	// Use reflection to set field values based on form data
+	structValue := reflect.ValueOf(structure)
+	if structValue.Kind() != reflect.Ptr || structValue.Elem().Kind() != reflect.Struct {
+		return errors.New("invalid structure, must be a pointer to a struct")
+	}
+	structElem := structValue.Elem()
+	for key, values := range r.Form {
+		field := structElem.FieldByName(key)
+		if !field.IsValid() {
+			// Skip fields that don't exist in the structure
+			continue
 		}
-
-		// Use reflection to set field values based on form data
-		structValue := reflect.ValueOf(structure)
-		if structValue.Kind() != reflect.Ptr || structValue.Elem().Kind() != reflect.Struct {
-			return errors.New("invalid structure, must be a pointer to a struct")
-		}
-		structElem := structValue.Elem()
-		structType := structElem.Type()
-		log.Println("structtype=", structType)
-		for key, values := range r.Form {
-			field := structElem.FieldByName(key)
-			if !field.IsValid() {
-				continue // Skip fields that don't exist in the structure
-			}
-
-			// Handle fields with different types (e.g., slice or single value)
-			if len(values) == 1 {
-				log.Println(reflect.ValueOf(values[0]), "value")
-				log.Println(field.Type(), "feild")
-				log.Println(reflect.ValueOf(values[0]).Type(), "type")
-				value := reflect.ValueOf(values[0])
-				if value.Type().ConvertibleTo(field.Type()) {
-					field.Set(value.Convert(field.Type()))
+		// Handle fields with different types (e.g., slice or single value)
+		if len(values) == 1 {
+			value := values[0]
+			//conversion of the data came according to the feilds values that are used in the struct
+			switch field.Kind() {
+			case reflect.Int:
+				intValue, err := strconv.Atoi(value)
+				if err != nil {
+					return err
 				}
-			} else {
-				// Handle fields with multiple values as a slice (if field is a slice)
-				if field.Kind() == reflect.Slice {
-					sliceType := field.Type().Elem()
-					slice := reflect.MakeSlice(field.Type(), len(values), len(values))
+				field.SetInt(int64(intValue))
+			case reflect.Int8:
+				int8Value, err := strconv.ParseInt(value, 10, 8)
+				if err != nil {
+					return err
+				}
+				field.SetInt(int64(int8(int8Value)))
+			case reflect.Int16:
+				int16Value, err := strconv.ParseInt(value, 10, 16)
+				if err != nil {
+					return err
+				}
+				field.SetInt(int64(int16(int16Value)))
+			case reflect.Int32:
+				int32Value, err := strconv.ParseInt(value, 10, 32)
+				if err != nil {
+					return err
+				}
+				field.SetInt(int64(int32(int32Value)))
+			case reflect.Int64:
+				int64Value, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return err
+				}
+				field.SetInt(int64Value)
+			case reflect.Float32:
+				float32Value, err := strconv.ParseFloat(value, 32)
+				if err != nil {
+					return err
+				}
+				field.SetFloat(float64(float32(float32Value)))
+			case reflect.Float64:
+				float64Value, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					return err
+				}
+				field.SetFloat(float64(float64Value))
+			case reflect.Bool:
+				boolValue, err := strconv.ParseBool(value)
+				if err != nil {
+					return err
+				}
+				field.SetBool(boolValue)
+			case reflect.String:
+				field.SetString(value)
+			}
+		} else {
+			// Handle fields with multiple values as a slice (if field is a slice)
+			if field.Kind() == reflect.Slice {
+				sliceType := field.Type().Elem()
+				slice := reflect.MakeSlice(field.Type(), len(values), len(values))
 
-					for i, v := range values {
-						elemValue := reflect.ValueOf(v)
-						if elemValue.Type().ConvertibleTo(sliceType) {
-							slice.Index(i).Set(elemValue.Convert(sliceType))
-						}
+				for i, v := range values {
+					elemValue := reflect.ValueOf(v)
+					if elemValue.Type().ConvertibleTo(sliceType) {
+						slice.Index(i).Set(elemValue.Convert(sliceType))
 					}
-
-					field.Set(slice)
 				}
+
+				field.Set(slice)
 			}
 		}
-		return err
 	}
-	return errors.New("The value of the environment variable APP_IS is invalid or Not set. It should be [monolith or microservice]. Please update the environment variable and try again.")
+	return err
+
+}
+func RenderJsonResponse(w http.ResponseWriter, r *http.Request, data interface{}) {
+	jsonresponce, err := json.Marshal(data)
+	if err != nil {
+		log.Println(err)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
+	w.Write([]byte(jsonresponce))
 }
 
-// func StrictParseDataFromRequest(r *http.Request, structure struct{}) (struct{}, error) {
-// 	if os.Getenv("APP_IS") == "monolith" {
-// 		err := json.NewDecoder(r.Body).Decode(&structure)
-// 		if err != nil {
-// 			return structure, err
-// 		}
-// 		return structure, err
-
-// 	} else if os.Getenv("APP_IS") == "microservice" {
-// 		formData := make(map[string]interface{})
-// 		err := r.ParseForm()
-// 		if err != nil {
-// 			return structure, err
-// 		}
-
-// 		// Iterate through the form values
-// 		for key, values := range r.Form {
-// 			// If there's only one value for the key, store it directly
-// 			if len(values) == 1 {
-// 				formData[key] = values[0]
-// 			} else {
-// 				// If there are multiple values, store them as a slice
-// 				formData[key] = values
-// 			}
-// 		}
-
-// 		return structure, nil
-// 	}
-// 	return nil, errors.New("The value of the environment variable APP_IS is invalid or Not set. It should be [monolith or microservice]. Please update the environment variable and try again.")
-// }
+func RenderTemplateData(w http.ResponseWriter, r *http.Request, template string, data interface{}) {
+	session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
+	tmplData := make(map[string]interface{})
+	tmplData["data"] = data
+	tmplData["flash"] = viewFlash(w, r)
+	tmplData["session"] = session.Values["email"]
+	View.ExecuteTemplate(w, template, tmplData)
+}

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -3,6 +3,7 @@ package utility
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"reflect"
@@ -117,7 +118,7 @@ func RenderTemplate(w http.ResponseWriter, r *http.Request, template string, dat
 	View.ExecuteTemplate(w, template, tmplData)
 }
 
-func ParseDataFromPostFormRequest(r *http.Request) (map[string]interface{}, error) {
+func ParseDataFromPostRequestToMap(r *http.Request) (map[string]interface{}, error) {
 	formData := make(map[string]interface{})
 	err := r.ParseForm()
 	if err != nil {
@@ -138,7 +139,7 @@ func ParseDataFromPostFormRequest(r *http.Request) (map[string]interface{}, erro
 	return formData, nil
 }
 
-func ParseDataFromJson(r *http.Request) (map[string]interface{}, error) {
+func ParseDataFromJsonToMap(r *http.Request) (map[string]interface{}, error) {
 	var jsonDataMap map[string]interface{}
 	result := make(map[string]interface{})
 
@@ -168,7 +169,7 @@ func StrictParseDataFromJson(r *http.Request, structure interface{}) error {
 
 }
 
-func StrictParseDataFromPostFormRequest(r *http.Request, structure interface{}) error {
+func StrictParseDataFromPostRequest(r *http.Request, structure interface{}) error {
 	err := r.ParseForm()
 	if err != nil {
 		return err
@@ -176,7 +177,7 @@ func StrictParseDataFromPostFormRequest(r *http.Request, structure interface{}) 
 	// Use reflection to set field values based on form data
 	structValue := reflect.ValueOf(structure)
 	if structValue.Kind() != reflect.Ptr || structValue.Elem().Kind() != reflect.Struct {
-		return errors.New("invalid structure, must be a pointer to a struct")
+		return errors.New("invalid argument: 'interface{}' must be a pointer to a struct")
 	}
 	structElem := structValue.Elem()
 	for key, values := range r.Form {
@@ -193,49 +194,49 @@ func StrictParseDataFromPostFormRequest(r *http.Request, structure interface{}) 
 			case reflect.Int:
 				intValue, err := strconv.Atoi(value)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to int: %v", err)
 				}
 				field.SetInt(int64(intValue))
 			case reflect.Int8:
 				int8Value, err := strconv.ParseInt(value, 10, 8)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to int8: %v", err)
 				}
 				field.SetInt(int64(int8(int8Value)))
 			case reflect.Int16:
 				int16Value, err := strconv.ParseInt(value, 10, 16)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to int16: %v", err)
 				}
 				field.SetInt(int64(int16(int16Value)))
 			case reflect.Int32:
 				int32Value, err := strconv.ParseInt(value, 10, 32)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to int32: %v", err)
 				}
 				field.SetInt(int64(int32(int32Value)))
 			case reflect.Int64:
 				int64Value, err := strconv.ParseInt(value, 10, 64)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to int64: %v", err)
 				}
 				field.SetInt(int64Value)
 			case reflect.Float32:
 				float32Value, err := strconv.ParseFloat(value, 32)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to float32: %v", err)
 				}
 				field.SetFloat(float64(float32(float32Value)))
 			case reflect.Float64:
 				float64Value, err := strconv.ParseFloat(value, 64)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to float64: %v", err)
 				}
 				field.SetFloat(float64(float64Value))
 			case reflect.Bool:
 				boolValue, err := strconv.ParseBool(value)
 				if err != nil {
-					return err
+					return fmt.Errorf("Error in converting string to bool: %v", err)
 				}
 				field.SetBool(boolValue)
 			case reflect.String:

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -1,111 +1,151 @@
 package utility
 
 import (
-    "os"
-    "log"
-    //"log"
-    //"fmt"
-    "net/http"
-    "html/template"
-    "github.com/gorilla/sessions"
-    "github.com/jmoiron/sqlx"
+	"encoding/json"
+	"log"
+	"os"
+
+	//"log"
+	//"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+	"github.com/jmoiron/sqlx"
 )
 
 // Template Pool
 var View *template.Template
+
 // Session Store
 var Store *sessions.FilesystemStore
+
 // DB Connections
 var Db *sqlx.DB
 
 type Session struct {
-    Key string
-    Value interface{}
+	Key   string
+	Value interface{}
 }
 
 type Flash struct {
-    Type string
-    Message string
+	Type    string
+	Message string
 }
 
-func RedirectTo(w http.ResponseWriter, r *http.Request, path string){
-    http.Redirect(w, r, os.Getenv("APP_URL")+"/"+path, http.StatusFound)
+func RedirectTo(w http.ResponseWriter, r *http.Request, path string) {
+	http.Redirect(w, r, os.Getenv("APP_URL")+"/"+path, http.StatusFound)
 }
 
 func SessionSet(w http.ResponseWriter, r *http.Request, data Session) {
-    session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
-    // Set some session values.
-    session.Values[data.Key] = data.Value
-    // Save it before we write to the response/return from the handler.
-    err := session.Save(r, w)
-    if(err != nil){
-        log.Println(err)
-    }
+	session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
+	// Set some session values.
+	session.Values[data.Key] = data.Value
+	// Save it before we write to the response/return from the handler.
+	err := session.Save(r, w)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func SessionGet(r *http.Request, key string) interface{} {
-    session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
-    // Set some session values.
-    return session.Values[key]
+	session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
+	// Set some session values.
+	return session.Values[key]
 }
-
 
 func CheckACL(w http.ResponseWriter, r *http.Request, minLevel int) bool {
-    userType := SessionGet(r, "type")
-    var level int = 0
-    switch(userType){
-    case "user":
-        level = 1
-    case "admin":
-        level = 2
-    default:
-        level = 0
-    }
-    if(level >= minLevel){
-        return true
-    } else {
-        RedirectTo(w, r, "forbidden")
-        return false
-    }
+	userType := SessionGet(r, "type")
+	var level int = 0
+	switch userType {
+	case "user":
+		level = 1
+	case "admin":
+		level = 2
+	default:
+		level = 0
+	}
+	if level >= minLevel {
+		return true
+	} else {
+		RedirectTo(w, r, "forbidden")
+		return false
+	}
 }
 
-func AddFlash(flavour string, message string, w http.ResponseWriter, r *http.Request){
-    session, err := Store.Get(r, os.Getenv("SESSION_NAME"))
-    if err != nil {
-        http.Error(w, err.Error(), http.StatusInternalServerError)
-    }
-    //flash := make(map[string]string)
-    //flash["Flavour"] = flavour
-    //flash["Message"] = message
-    flash := Flash {
-        Type: flavour,
-        Message: message,
-    }
-    session.AddFlash(flash, "message")
-    err = session.Save(r, w)
-    if (err != nil){
-        log.Println(err)
-    }
+func AddFlash(flavour string, message string, w http.ResponseWriter, r *http.Request) {
+	session, err := Store.Get(r, os.Getenv("SESSION_NAME"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	//flash := make(map[string]string)
+	//flash["Flavour"] = flavour
+	//flash["Message"] = message
+	flash := Flash{
+		Type:    flavour,
+		Message: message,
+	}
+	session.AddFlash(flash, "message")
+	err = session.Save(r, w)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
-func viewFlash(w http.ResponseWriter, r *http.Request) interface{}{
-  session, err := Store.Get(r, os.Getenv("SESSION_NAME"))
-  if err != nil {
-    http.Error(w, err.Error(), http.StatusInternalServerError)
-  }
-  fm := session.Flashes("message")
-  if fm == nil {
-    return nil
-  }
-  session.Save(r, w)
-  return fm
+func viewFlash(w http.ResponseWriter, r *http.Request) interface{} {
+	session, err := Store.Get(r, os.Getenv("SESSION_NAME"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	fm := session.Flashes("message")
+	if fm == nil {
+		return nil
+	}
+	session.Save(r, w)
+	return fm
 }
 
-func RenderTemplate(w http.ResponseWriter, r *http.Request, template string, data interface{}){
-    session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
-    tmplData := make(map[string]interface{})
-    tmplData["data"] = data
-    tmplData["flash"] = viewFlash(w, r)
-    tmplData["session"] = session.Values["email"]
-    View.ExecuteTemplate(w, template, tmplData)
+func RenderTemplate(w http.ResponseWriter, r *http.Request, template string, data interface{}) {
+	session, _ := Store.Get(r, os.Getenv("SESSION_NAME"))
+	tmplData := make(map[string]interface{})
+	tmplData["data"] = data
+	tmplData["flash"] = viewFlash(w, r)
+	tmplData["session"] = session.Values["email"]
+	View.ExecuteTemplate(w, template, tmplData)
+}
+func createStructFromJSON(jsonData []byte) (map[string]interface{}, error) {
+	var jsonDataMap map[string]interface{}
+	result := make(map[string]interface{})
+	err := json.Unmarshal(jsonData, &jsonDataMap)
+	if err != nil {
+		log.Println(err)
+		return result, err
+	}
+
+	for key, value := range jsonDataMap {
+		result[key] = value
+	}
+
+	return result, err
+}
+func createStructFromHTTPRequest(r *http.Request) (map[string]interface{}, error) {
+	var jsonDataMap map[string]interface{}
+	result := make(map[string]interface{})
+
+	// Read JSON data from the HTTP request body
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&jsonDataMap)
+	if err != nil {
+		log.Println(err)
+		return result, err
+	}
+
+	// Close the request body to prevent resource leaks
+	defer r.Body.Close()
+
+	for key, value := range jsonDataMap {
+		result[key] = value
+	}
+
+	return result, err
 }


### PR DESCRIPTION
In this pull request, we introduce a set of utility functions aimed at enhancing our data parsing and rendering capabilities. These functions are designed to improve the flexibility and ease of handling incoming requests and rendering responses in various scenarios.

New Functions:

`StrictParseDataFromPostForm(r *http.Request, structure interface{}) error`
This function parses data from an HTTP POST form request and converts it into the exact structure specified by the structure argument, which should be a pointer to the target structure.

`StrictParseDataFromAjaxRequest(r *http.Request, structure interface{}) error`
Similar to the previous function, this one parses data from an AJAX request and converts it into the specified structure. Again, the structure argument should be a pointer to the desired structure.

`ParseDataFromAjaxRequest(r *http.Request) (map[string]interface{}, error)`
This function is used for parsing data from an AJAX request and returning it as a map[string]interface{}. It does not decode the request data into an exact structure but is useful for handling data in a more flexible manner.

`ParseDataFromPostForm(r *http.Request) (map[string]interface{}, error)`
Like the previous function, this one parses data from an HTTP POST form request and returns it as a map[string]interface{}. It is not meant for decoding data into a specific structure but for more generic data parsing.

Rendering and Response Strategy:

We have also included a strategy for rendering templates and handling responses. Depending on the environment variables, we are offering multiple options:

    Initially, we will use w.Write for rendering the response.
    If the required header support is not found, we have a fallback option to switch to an alternative rendering method.

This approach ensures clarity in response handling and allows us to adapt to different scenarios smoothly.