### PR TITLE
12 implement cached header auth

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -38,9 +38,7 @@ func CheckACL(w http.ResponseWriter, r *http.Request, allowedAccess []string) bo
 		if userType == nil {
 			userType = "guest"
 		}
-		if utility.StringInArray(fmt.Sprintf("%v", userType), allowedAccess) {
-			return true
-		} else {
+		if !utility.StringInArray(fmt.Sprintf("%v", userType), allowedAccess) {
 			utility.RedirectTo(w, r, "forbidden")
 			return false
 		}
@@ -48,9 +46,9 @@ func CheckACL(w http.ResponseWriter, r *http.Request, allowedAccess []string) bo
 		// Token based Auth
 		err := models.VerifyToken(r)
 		if err != nil {
-			return true
-		} else {
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
 			return false
 		}
 	}
+	return true
 }

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -46,6 +46,11 @@ func CheckACL(w http.ResponseWriter, r *http.Request, allowedAccess []string) bo
 		}
 	} else {
 		// Token based Auth
-		models.VerifyToken(r)
+		err := models.VerifyToken(r)
+		if err != nil {
+			return true
+		} else {
+			return false
+		}
 	}
 }

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -13,11 +13,11 @@ func BaseIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func BaseAPI(w http.ResponseWriter, r *http.Request) {
-	data, err := models.VerifyToken(r, false)
+	log.Println(r.Header.Get("tokenPayload"))
+	err := models.VerifyToken(r)
 	if err != nil {
 		// Redirect to 403
 	} else {
-		log.Println(data)
 		name := []string{"Test1", "Test2"}
 		utility.RenderTemplate(w, r, "index", name)
 	}

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -1,15 +1,28 @@
 package controllers
 
 import (
+	"log"
 	"net/http"
+	"reakgo/models"
 	"reakgo/utility"
 )
 
 func BaseIndex(w http.ResponseWriter, r *http.Request) {
-    name := []string{"Test1", "Test2"}
-    utility.RenderTemplate(w, r, "index", name)
+	name := []string{"Test1", "Test2"}
+	utility.RenderTemplate(w, r, "index", name)
+}
+
+func BaseAPI(w http.ResponseWriter, r *http.Request) {
+	data, err := models.VerifyToken(r)
+	if err != nil {
+		// Redirect to 403
+	} else {
+		log.Println(data)
+		name := []string{"Test1", "Test2"}
+		utility.RenderTemplate(w, r, "index", name)
+	}
 }
 
 func Dashboard(w http.ResponseWriter, r *http.Request) {
-    utility.RenderTemplate(w, r, "dashboard", nil)
+	utility.RenderTemplate(w, r, "dashboard", nil)
 }

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -13,7 +13,7 @@ func BaseIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func BaseAPI(w http.ResponseWriter, r *http.Request) {
-	data, err := models.VerifyToken(r)
+	data, err := models.VerifyToken(r, false)
 	if err != nil {
 		// Redirect to 403
 	} else {

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -1,26 +1,13 @@
 package controllers
 
 import (
-	"log"
 	"net/http"
-	"reakgo/models"
 	"reakgo/utility"
 )
 
 func BaseIndex(w http.ResponseWriter, r *http.Request) {
 	name := []string{"Test1", "Test2"}
 	utility.RenderTemplate(w, r, "index", name)
-}
-
-func BaseAPI(w http.ResponseWriter, r *http.Request) {
-	log.Println(r.Header.Get("tokenPayload"))
-	err := models.VerifyToken(r)
-	if err != nil {
-		// Redirect to 403
-	} else {
-		name := []string{"Test1", "Test2"}
-		utility.RenderTemplate(w, r, "index", name)
-	}
 }
 
 func Dashboard(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module reakgo
 go 1.15
 
 require (
+	github.com/allegro/bigcache/v3 v3.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/models/authentication.go
+++ b/models/authentication.go
@@ -101,3 +101,7 @@ func (auth Authentication) CheckTwoFactorRegistration(userId int32) string {
 	utility.Db.Get(&twoFactor, "SELECT * FROM twoFactor WHERE userId = ?", userId)
 	return twoFactor.Secret
 }
+
+func (auth Authentication) GetAllRecords() ([]Authentication, error) {
+
+}

--- a/models/authentication.go
+++ b/models/authentication.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"database/sql"
+	"fmt"
 	"log"
 	"reakgo/utility"
 	"time"
@@ -102,6 +104,35 @@ func (auth Authentication) CheckTwoFactorRegistration(userId int32) string {
 	return twoFactor.Secret
 }
 
-func (auth Authentication) GetAllRecords() ([]Authentication, error) {
+func (auth Authentication) GetAllAuthRecords() ([]Authentication, error) {
+	var allAuthenticationRows []Authentication
 
+	// SQL query to select all rows from the Abc table
+	query := "SELECT * FROM authentication"
+
+	// Execute the query and scan the results into the Abc slice
+	err := utility.Db.Select(&allAuthenticationRows, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return allAuthenticationRows, nil
+}
+
+func (auth Authentication) GetAuthenticationByToken(token string) (*Authentication, error) {
+
+	var authO Authentication
+
+	// SQL query to select a row by Token
+	query := "SELECT * FROM authentication WHERE Token = ? LIMIT 1"
+
+	// Execute the query and scan the result into the Authentication struct
+	err := utility.Db.Get(&authO, query, token)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("Authentication not found for Token: %s", token)
+		}
+		return nil, err
+	}
+	return &authO, nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -3,6 +3,8 @@ package models
 import (
 	"database/sql"
 	"errors"
+	"fmt"
+	"reakgo/utility"
 )
 
 var (
@@ -23,4 +25,16 @@ func standardizeError(err error) error {
 	}
 
 	return err
+}
+
+func GenerateCache() {
+
+}
+
+func VerifyToken() {
+	if entry, err := utility.Cache.Get("my-unique-key"); err == nil {
+		fmt.Println(string(entry))
+	} else {
+		// Pull Record from DB and add to Cache
+	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -2,8 +2,9 @@ package models
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
-	"fmt"
+	"log"
 	"reakgo/utility"
 )
 
@@ -28,13 +29,27 @@ func standardizeError(err error) error {
 }
 
 func GenerateCache() {
-
+	allRows, err := Authentication{}.GetAllAuthRecords()
+	if err != nil {
+		log.Println(err)
+	} else {
+		for _, val := range allRows {
+			jsonData, err := json.Marshal(val)
+			if err != nil {
+				log.Println("Error encoding JSON:", err)
+				break
+			}
+			utility.Cache.Set(val.Token, jsonData)
+		}
+	}
 }
 
 func VerifyToken() {
-	if entry, err := utility.Cache.Get("my-unique-key"); err == nil {
-		fmt.Println(string(entry))
+	if entry, err := utility.Cache.Get("123"); err == nil {
+		log.Println(string(entry))
 	} else {
 		// Pull Record from DB and add to Cache
+		data, err := Authentication.GetAuthenticationByToken(Authentication{}, "123")
+		log.Println(data, err)
 	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -75,8 +75,14 @@ func VerifyToken(r *http.Request) (*Authentication, error) {
 			// Rehydrate if we got the JSON conversion done
 			// Fails would be rare, but if it happens kind of defeat the purpose as JSON unmarshall would also crash
 			utility.Cache.Set(data.Token, jsonData)
+		} else {
+			return nil, err
 		}
-		return data, err
+		if returnUserData {
+			return data, err
+		} else {
+			return nil, nil
+		}
 	}
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -45,11 +45,24 @@ func GenerateCache() {
 }
 
 func VerifyToken() {
-	if entry, err := utility.Cache.Get("123"); err == nil {
-		log.Println(string(entry))
+	if entry, err := utility.Cache.Get("456"); err == nil {
+		// JSON to Struct for data consistency if coming in from DB or from cache
+		authRow, err := jsonStringToAuthentication(string(entry))
+		log.Println(authRow, err)
 	} else {
 		// Pull Record from DB and add to Cache
 		data, err := Authentication.GetAuthenticationByToken(Authentication{}, "123")
 		log.Println(data, err)
 	}
+}
+
+func jsonStringToAuthentication(jsonStr string) (*Authentication, error) {
+	var auth Authentication
+
+	// Unmarshal the JSON string into the Authentication struct
+	if err := json.Unmarshal([]byte(jsonStr), &auth); err != nil {
+		return nil, err
+	}
+
+	return &auth, nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -13,8 +13,8 @@ func Routes(w http.ResponseWriter, r *http.Request) {
 	route := strings.Trim(r.URL.Path, "/")
 	switch route {
 	case "", "index":
-		utility.CheckACL(w, r, 0)
-		controllers.BaseIndex(w, r)
+		//utility.CheckACL(w, r, 0)
+		controllers.BaseAPI(w, r)
 	case "login":
 		utility.CheckACL(w, r, 0)
 		controllers.Login(w, r)

--- a/router/router.go
+++ b/router/router.go
@@ -13,7 +13,7 @@ func Routes(w http.ResponseWriter, r *http.Request) {
 	switch route {
 	case "", "index":
 		controllers.CheckACL(w, r, []string{"guest", "admin", "user"})
-		controllers.BaseIndex(w, r)
+		controllers.BaseAPI(w, r)
 	case "login":
 		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.Login(w, r)

--- a/router/router.go
+++ b/router/router.go
@@ -12,14 +12,18 @@ func Routes(w http.ResponseWriter, r *http.Request) {
 	route := strings.Trim(r.URL.Path, "/")
 	switch route {
 	case "", "index":
-		controllers.CheckACL(w, r, []string{"guest", "admin", "user"})
-		controllers.BaseAPI(w, r)
+		check := controllers.CheckACL(w, r, []string{"guest", "admin", "user"})
+		if check {
+			controllers.BaseAPI(w, r)
+		}
 	case "login":
 		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.Login(w, r)
 	case "dashboard":
-		controllers.CheckACL(w, r, []string{"admin", "user"})
-		controllers.Dashboard(w, r)
+		check := controllers.CheckACL(w, r, []string{"admin", "user"})
+		if check {
+			controllers.Dashboard(w, r)
+		}
 	case "addSimpleForm":
 		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.AddForm(w, r)

--- a/router/router.go
+++ b/router/router.go
@@ -3,7 +3,6 @@ package router
 import (
 	"net/http"
 	"reakgo/controllers"
-	"reakgo/utility"
 	"strings"
 )
 
@@ -13,25 +12,25 @@ func Routes(w http.ResponseWriter, r *http.Request) {
 	route := strings.Trim(r.URL.Path, "/")
 	switch route {
 	case "", "index":
-		//utility.CheckACL(w, r, 0)
-		controllers.BaseAPI(w, r)
+		controllers.CheckACL(w, r, []string{"guest", "admin", "user"})
+		controllers.BaseIndex(w, r)
 	case "login":
-		utility.CheckACL(w, r, 0)
+		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.Login(w, r)
 	case "dashboard":
-		utility.CheckACL(w, r, 1)
+		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.Dashboard(w, r)
 	case "addSimpleForm":
-		utility.CheckACL(w, r, 0)
+		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.AddForm(w, r)
 	case "viewSimpleForm":
-		utility.CheckACL(w, r, 0)
+		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.ViewForm(w, r)
 	case "register-2fa":
-		utility.CheckACL(w, r, 1)
+		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.RegisterTwoFa(w, r)
 	case "verify-2fa":
-		utility.CheckACL(w, r, 1)
+		controllers.CheckACL(w, r, []string{"admin", "user"})
 		controllers.VerifyTwoFa(w, r)
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -14,7 +14,7 @@ func Routes(w http.ResponseWriter, r *http.Request) {
 	case "", "index":
 		check := controllers.CheckACL(w, r, []string{"guest", "admin", "user"})
 		if check {
-			controllers.BaseAPI(w, r)
+			controllers.BaseIndex(w, r)
 		}
 	case "login":
 		controllers.CheckACL(w, r, []string{"admin", "user"})

--- a/server.go
+++ b/server.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"encoding/gob"
 	"html/template"
 	"log"
 	"net/http"
@@ -8,11 +10,12 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-    "encoding/gob"
 
+	"reakgo/models"
 	"reakgo/router"
 	"reakgo/utility"
 
+	"github.com/allegro/bigcache/v3"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gorilla/sessions"
 	"github.com/jmoiron/sqlx"
@@ -20,94 +23,92 @@ import (
 )
 
 func init() {
-    // Set log configuration
-    log.SetFlags(log.LstdFlags | log.Lshortfile)
-    var err error
-    err = godotenv.Load()
-    if err != nil {
-        log.Println(".env file wasn't found, looking at env variables")
-    }
-    motd()
-    // Read Config
-    utility.Db, err = sqlx.Open("mysql", os.Getenv("DB_USER")+":"+os.Getenv("DB_PASSWORD")+"@/"+os.Getenv("DB_NAME"))
-    if err != nil {
-        log.Println("Wowza !, We didn't find the DB or you forgot to setup the env variables")
-        panic(err)
-    }
-    utility.Store = sessions.NewFilesystemStore("",[]byte(os.Getenv("SESSION_KEY")))
-    utility.Store.Options = &sessions.Options{
-        Path: "/",
-        MaxAge: 60*1,
-        HttpOnly: true,
-    }
-    utility.View = cacheTemplates()
-    // See "Important settings" section.
-    utility.Db.SetConnMaxLifetime(time.Minute * 3)
-    utility.Db.SetMaxOpenConns(10)
-    utility.Db.SetMaxIdleConns(10)
+	// Set log configuration
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	var err error
+	err = godotenv.Load()
+	if err != nil {
+		log.Println(".env file wasn't found, looking at env variables")
+	}
+	motd()
+	// Read Config
+	utility.Db, err = sqlx.Open("mysql", os.Getenv("DB_USER")+":"+os.Getenv("DB_PASSWORD")+"@/"+os.Getenv("DB_NAME"))
+	if err != nil {
+		log.Println("Wowza !, We didn't find the DB or you forgot to setup the env variables")
+		panic(err)
+	}
+	utility.Store = sessions.NewFilesystemStore("", []byte(os.Getenv("SESSION_KEY")))
+	utility.Store.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   60 * 1,
+		HttpOnly: true,
+	}
+	utility.View = cacheTemplates()
+	// See "Important settings" section.
+	utility.Db.SetConnMaxLifetime(time.Minute * 3)
+	utility.Db.SetMaxOpenConns(10)
+	utility.Db.SetMaxIdleConns(10)
 
-    gob.Register(utility.Flash{})
+	gob.Register(utility.Flash{})
 
 }
 
 func main() {
-    http.HandleFunc("/", handler)
-    // Serve static assets
-    http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./assets"))))
-    
-    /*
-    router := mux.NewRouter()
-    router.HandleFunc("/", controllers.BaseIndex)
-    router.HandleFunc("/login", controllers.Login)
-    router.HandleFunc("/dashboard", controllers.Dashboard)
-    */
 
-    log.Fatal(http.ListenAndServe(":"+os.Getenv("WEB_PORT"), nil))
+	// Initialize Caching
+	cacheInit()
+	go models.GenerateCache()
+
+	http.HandleFunc("/", handler)
+	// Serve static assets
+	http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./assets"))))
+
+	log.Fatal(http.ListenAndServe(":"+os.Getenv("WEB_PORT"), nil))
 }
 
 func cacheTemplates() *template.Template {
 
-    funcMap := template.FuncMap{
-        // Only to be used for SAFE attributes, SAFE = Computer Generated and not USER DRIVEN
-        "attr":func(s string) template.HTMLAttr{
-            return template.HTMLAttr(s)
-        },
-        // Only to be used for SAFE HTML, SAFE = Computer Generated and not USER DRIVEN
-        "safe": func(s string) template.HTML {
-            return template.HTML(s)
-         },
-        // Only to be used for SAFE URLs, SAFE = Computer Generated and not USER DRIVEN
-         "safeURL": func(s string) template.URL {
-            return template.URL(s)
-         },
-    }
+	funcMap := template.FuncMap{
+		// Only to be used for SAFE attributes, SAFE = Computer Generated and not USER DRIVEN
+		"attr": func(s string) template.HTMLAttr {
+			return template.HTMLAttr(s)
+		},
+		// Only to be used for SAFE HTML, SAFE = Computer Generated and not USER DRIVEN
+		"safe": func(s string) template.HTML {
+			return template.HTML(s)
+		},
+		// Only to be used for SAFE URLs, SAFE = Computer Generated and not USER DRIVEN
+		"safeURL": func(s string) template.URL {
+			return template.URL(s)
+		},
+	}
 
-    templ := template.New("")
-    templ.Funcs(funcMap)
-    err := filepath.Walk("./templates", func(path string, info os.FileInfo, err error) error {
-        if strings.Contains(path, ".html") {
-            _, err = templ.ParseFiles(path)
-            if err != nil {
-                log.Println(err)
-            }
-        }
+	templ := template.New("")
+	templ.Funcs(funcMap)
+	err := filepath.Walk("./templates", func(path string, info os.FileInfo, err error) error {
+		if strings.Contains(path, ".html") {
+			_, err = templ.ParseFiles(path)
+			if err != nil {
+				log.Println(err)
+			}
+		}
 
-        return err
-    })
+		return err
+	})
 
-    if err != nil {
-        panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 
-    return templ
+	return templ
 }
 
-func handler(w http.ResponseWriter, r *http.Request){
-    router.Routes(w, r)
+func handler(w http.ResponseWriter, r *http.Request) {
+	router.Routes(w, r)
 }
 
-func motd(){
-    logo := `
+func motd() {
+	logo := `
 ______ _____  ___   _   __
 | ___ \  ___|/ _ \ | | / /
 | |_/ / |__ / /_\ \| |/ / 
@@ -116,8 +117,55 @@ ______ _____  ___   _   __
 \_| \_\____/\_| |_/\_| \_/
                           
 ----------------------------
-Application should now be accessible on port `+os.Getenv("WEB_PORT")+`
+Application should now be accessible on port ` + os.Getenv("WEB_PORT") + `
 
 `
-    log.Println(logo)
+	log.Println(logo)
+}
+
+func cacheInit() {
+	config := bigcache.Config{
+		// number of shards (must be a power of 2)
+		Shards: 1024,
+
+		// time after which entry can be evicted
+		LifeWindow: 10 * time.Minute,
+
+		// Interval between removing expired entries (clean up).
+		// If set to <= 0 then no action is performed.
+		// Setting to < 1 second is counterproductive — bigcache has a one second resolution.
+		CleanWindow: 5 * time.Minute,
+
+		// rps * lifeWindow, used only in initial memory allocation
+		MaxEntriesInWindow: 1000 * 10 * 60,
+
+		// max entry size in bytes, used only in initial memory allocation
+		MaxEntrySize: 500,
+
+		// prints information about additional memory allocation
+		Verbose: true,
+
+		// cache will not allocate more memory than this limit, value in MB
+		// if value is reached then the oldest entries can be overridden for the new ones
+		// 0 value means no size limit
+		HardMaxCacheSize: 8192,
+
+		// callback fired when the oldest entry is removed because of its expiration time or no space left
+		// for the new entry, or because delete was called. A bitmask representing the reason will be returned.
+		// Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
+		OnRemove: nil,
+
+		// OnRemoveWithReason is a callback fired when the oldest entry is removed because of its expiration time or no space left
+		// for the new entry, or because delete was called. A constant representing the reason will be passed through.
+		// Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
+		// Ignored if OnRemove is specified.
+		OnRemoveWithReason: nil,
+	}
+
+	var err error
+
+	utility.Cache, err = bigcache.New(context.Background(), config)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/server.go
+++ b/server.go
@@ -104,6 +104,7 @@ func cacheTemplates() *template.Template {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
+	models.VerifyToken()
 	router.Routes(w, r)
 }
 

--- a/server.go
+++ b/server.go
@@ -57,6 +57,8 @@ func main() {
 
 	// Initialize Caching
 	cacheInit()
+	// Generate cache as a go routine as to not halt operation,
+	// Cache fail-safe is already implemented so will fetch from DB incase the cache is not populated
 	go models.GenerateCache()
 
 	http.HandleFunc("/", handler)
@@ -104,7 +106,6 @@ func cacheTemplates() *template.Template {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	models.VerifyToken()
 	router.Routes(w, r)
 }
 
@@ -149,7 +150,7 @@ func cacheInit() {
 		// cache will not allocate more memory than this limit, value in MB
 		// if value is reached then the oldest entries can be overridden for the new ones
 		// 0 value means no size limit
-		HardMaxCacheSize: 8192,
+		HardMaxCacheSize: 512,
 
 		// callback fired when the oldest entry is removed because of its expiration time or no space left
 		// for the new entry, or because delete was called. A bitmask representing the reason will be returned.

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -78,25 +78,6 @@ func SessionGet(r *http.Request, key string) interface{} {
 	return session.Values[key]
 }
 
-func CheckACL(w http.ResponseWriter, r *http.Request, minLevel int) bool {
-	userType := SessionGet(r, "type")
-	var level int = 0
-	switch userType {
-	case "user":
-		level = 1
-	case "admin":
-		level = 2
-	default:
-		level = 0
-	}
-	if level >= minLevel {
-		return true
-	} else {
-		RedirectTo(w, r, "forbidden")
-		return false
-	}
-}
-
 func AddFlash(flavour string, message string, w http.ResponseWriter, r *http.Request) {
 	session, err := Store.Get(r, os.Getenv("SESSION_NAME"))
 	if err != nil {
@@ -301,4 +282,14 @@ func RenderTemplateData(w http.ResponseWriter, r *http.Request, template string,
 	tmplData["flash"] = viewFlash(w, r)
 	tmplData["session"] = session.Values["email"]
 	View.ExecuteTemplate(w, template, tmplData)
+}
+
+func StringInArray(target string, arr []string) bool {
+	// Can change to slices.Contain if we're targetting 1.21+
+	for _, s := range arr {
+		if s == target {
+			return true
+		}
+	}
+	return false
 }

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -16,6 +16,7 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/allegro/bigcache/v3"
 	"github.com/gorilla/sessions"
 	"github.com/jmoiron/sqlx"
 )
@@ -28,6 +29,9 @@ var Store *sessions.FilesystemStore
 
 // DB Connections
 var Db *sqlx.DB
+
+// Cache
+var Cache *bigcache.BigCache
 
 type Session struct {
 	Key   string


### PR DESCRIPTION
Closes #12 

Implements a cached token authentication setup which checks the token supplied by user against a cached list and also directly against the DB (re-hydrating the cache) if it's not available within the cache.

The changes proposed acts a middleware overwriting the header adding `tokenPayload` header with the authentication data which is to be consumed at the controller layer for various checks and DB interaction.